### PR TITLE
6 create basic work experience component

### DIFF
--- a/app/project-structure/data.ts
+++ b/app/project-structure/data.ts
@@ -56,7 +56,7 @@ const responsibilities: Responsability[] = [
 
 export const cvData: CvData = {
   name: "Christian Koch Echeverria",
-  role: "Software Engineering with focus on React-based systems",
+  role: "Software Engineer with focus on React-based systems",
   about: {
     heading: "About",
     content:

--- a/app/project-structure/data.ts
+++ b/app/project-structure/data.ts
@@ -1,4 +1,5 @@
 import { Skill } from "./skill";
+import { Responsability, WorkExperience } from "./work-experience-card";
 
 export interface CvData {
   name: string;
@@ -13,11 +14,7 @@ export interface CvData {
   };
   experience: {
     heading: string;
-    items: {
-      company: string;
-      position: string;
-      responsibilities: string[];
-    }[];
+    items: WorkExperience[];
   };
 }
 
@@ -32,6 +29,29 @@ const skillsList: Skill[] = [
   { name: "Express", level: 4 },
   { name: "MongoDB", level: 4 },
   { name: "PostgreSQL", level: 4 },
+];
+
+const responsibilities: Responsability[] = [
+  {
+    responsibility: "Implementing new Features",
+    oneWordSummary: "Implementing",
+  },
+  {
+    responsibility: "Grooming tickets before sprint",
+    oneWordSummary: "Grooming",
+  },
+  {
+    responsibility: "Fixing bugs during and in-between sprints",
+    oneWordSummary: "Fixing",
+  },
+  {
+    responsibility: "Improve performance and our code quality",
+    oneWordSummary: "Techncial Stories",
+  },
+  {
+    responsibility: "Aligning with Backend Team for Rest APIs",
+    oneWordSummary: "BE-FE Communication",
+  },
 ];
 
 export const cvData: CvData = {
@@ -52,13 +72,8 @@ export const cvData: CvData = {
       {
         company: "Valsight",
         position: "Frontend Web Developer",
-        responsibilities: [
-          "Implementing new Features",
-          "Grooming tickets before sprint",
-          "Fixing bugs during and in-between sprints",
-          "Tackling technical stories to improve performance and our code quality",
-          "Aligning with Backend Team for Rest APIs",
-        ],
+        responsibilities: responsibilities,
+        date: "2021 - Present",
       },
     ],
   },

--- a/app/project-structure/page.tsx
+++ b/app/project-structure/page.tsx
@@ -9,7 +9,7 @@ export default function CvPage() {
   const lotOfWhitespaceClassName = "mb-8";
   return (
     <div className="container flex flex-col mx-auto max-w-2xl">
-      <div className=" mt-20 mb-24">
+      <div className=" mt-20 mb-10">
         <CkH1>{cvData.name}</CkH1>
       </div>
       <TextSection>{cvData.role}</TextSection>
@@ -26,19 +26,6 @@ export default function CvPage() {
       <div className=" mt-14 mb-16">
         <CkH2>{cvData.experience.heading}</CkH2>
       </div>
-      {/* {cvData.experience.items.map((item, index) => (
-        <div key={index}>
-          <CkH3>{item.company}</CkH3>
-          <CkH3>{item.position}</CkH3>
-          <CkP>
-            <ul>
-              {item.responsibilities.map((responsibility, index) => (
-                <li key={index}>{responsibility}</li>
-              ))}
-            </ul>
-          </CkP>
-        </div>
-      ))} */}
       <WorkExperience workExperience={cvData.experience.items[0]} />
     </div>
   );

--- a/app/project-structure/page.tsx
+++ b/app/project-structure/page.tsx
@@ -3,6 +3,7 @@ import { cvData } from "./data";
 import { SkillIndicator } from "./skill";
 import SkillsSection from "./skills-section";
 import TextSection from "./text-section";
+import WorkExperience from "./work-experience-card";
 
 export default function CvPage() {
   const lotOfWhitespaceClassName = "mb-8";
@@ -25,7 +26,7 @@ export default function CvPage() {
       <div className=" mt-14 mb-16">
         <CkH2>{cvData.experience.heading}</CkH2>
       </div>
-      {cvData.experience.items.map((item, index) => (
+      {/* {cvData.experience.items.map((item, index) => (
         <div key={index}>
           <CkH3>{item.company}</CkH3>
           <CkH3>{item.position}</CkH3>
@@ -37,7 +38,8 @@ export default function CvPage() {
             </ul>
           </CkP>
         </div>
-      ))}
+      ))} */}
+      <WorkExperience workExperience={cvData.experience.items[0]} />
     </div>
   );
 }

--- a/app/project-structure/work-experience-card.tsx
+++ b/app/project-structure/work-experience-card.tsx
@@ -1,0 +1,58 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { CalendarIcon } from "@radix-ui/react-icons";
+import React from "react";
+export interface WorkExperience {
+  company: string;
+  position: string;
+  responsibilities: Responsability[];
+  date: string;
+}
+export interface Responsability {
+  responsibility: string;
+  oneWordSummary: string;
+}
+interface WorkExperienceCardProps {
+  workExperience: WorkExperience;
+}
+const WorkExperienceCard = ({ workExperience }: WorkExperienceCardProps) => {
+  const { company, position, responsibilities, date } = workExperience;
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{company}</CardTitle>
+        <CardDescription>{position}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {responsibilities.map((responsibility, index) => (
+          <div
+            key={responsibility.oneWordSummary}
+            className="flex w-full justify-between mb-4"
+          >
+            <div>{responsibility.responsibility}</div>
+            <div className="flex justify-start w-1/3">
+              <Badge variant={"default"}>{responsibility.oneWordSummary}</Badge>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+      <Separator />
+      <div className="flex w-full justify-start">
+        <div className="flex my-4 ml-4 items-start">
+          <CalendarIcon className="w-6 h-5 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">{date}</p>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default WorkExperienceCard;

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
# Description
- This PR adds the basic work experience component with a predesigned look:
<img width="666" alt="image" src="https://github.com/christian1koch/cv/assets/66799199/039648b6-7946-44d1-8b25-c9cb2d16969e">

- This also defines the following work wexperience interfaces
- `export interface WorkExperience {
  company: string;
  position: string;
  responsibilities: Responsability[];
  date: string;
}` 